### PR TITLE
Update config.toml to match cli update 4.1.2

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -1,11 +1,11 @@
 [api]
-host = "http://127.0.0.1:5555"
+url = "http://127.0.0.1:5555"
 use_tls = false
 zone_name = "default-zone"
 insecure = true
 
 [catalog]
-host = "http://127.0.0.1:8080"
+url = "http://127.0.0.1:8080"
 use_tls = false
 zone_name = "default-zone"
 insecure = true


### PR DESCRIPTION
cli 4.1.2 uses `url` instead of `host`